### PR TITLE
Hex Input Options

### DIFF
--- a/epochalypse.py
+++ b/epochalypse.py
@@ -103,6 +103,9 @@ def main():
       help='Hexadecimal timemstamp value to be converted',
       metavar='')
 
+  parser.add_argument("-r", "--revhex", action="store_true", default=False,
+      help="Reverse hex bytes (for little endian input)")
+
   if len(sys.argv) == 1:
     parser.print_help()
     sys.exit(1)
@@ -123,7 +126,10 @@ def main():
     fromEpoch(float(args.epoch_input))
     print('')
   elif args.hexadecimal_input:
-    epoch = fromHex(args.hexadecimal_input)
+    hex_text = args.hexadecimal_input.replace(' ', '')
+    if args.revhex:
+      hex_text = hex_text.decode('hex')[::-1].encode('hex')
+    epoch = fromHex(hex_text)
     fromEpoch(epoch)
     print('')
 

--- a/epochalypse.py
+++ b/epochalypse.py
@@ -18,6 +18,7 @@ import sys
 import time
 from datetime import datetime
 import argparse
+import binascii
 
 # The number of seconds between January 1, 1904 and Jan 1, 1970.
 HFS_OFFSET = 2082844800
@@ -128,7 +129,8 @@ def main():
   elif args.hexadecimal_input:
     hex_text = args.hexadecimal_input.replace(' ', '')
     if args.revhex:
-      hex_text = hex_text.decode('hex')[::-1].encode('hex')
+      hex_text = binascii.hexlify( binascii.unhexlify( hex_text )[::-1] ).decode()
+      print (hex_text)
     epoch = fromHex(hex_text)
     fromEpoch(epoch)
     print('')

--- a/epochalypse.py
+++ b/epochalypse.py
@@ -101,8 +101,7 @@ def main():
       help='Epoch time to be converted',
       metavar='')
   parser.add_argument('-x', '--hex', dest="hexadecimal_input", default=False,
-      help='Hexadecimal timemstamp value to be converted',
-      metavar='')
+      help='Hexadecimal timemstamp value to be converted', metavar='')
 
   parser.add_argument("-r", "--revhex", action="store_true", default=False,
       help="Reverse hex bytes (for little endian input)")

--- a/epochalypse.py
+++ b/epochalypse.py
@@ -130,7 +130,6 @@ def main():
     hex_text = args.hexadecimal_input.replace(' ', '')
     if args.revhex:
       hex_text = binascii.hexlify( binascii.unhexlify( hex_text )[::-1] ).decode()
-      print (hex_text)
     epoch = fromHex(hex_text)
     fromEpoch(epoch)
     print('')

--- a/epochalypse.py
+++ b/epochalypse.py
@@ -102,9 +102,8 @@ def main():
       metavar='')
   parser.add_argument('-x', '--hex', dest="hexadecimal_input", default=False,
       help='Hexadecimal timemstamp value to be converted', metavar='')
-
-  parser.add_argument("-r", "--revhex", action="store_true", default=False,
-      help="Reverse hex bytes (for little endian input)")
+  parser.add_argument('-r', '--revhex', action='store_true', default=False,
+      help='Reverse hex bytes (for little endian input)')
 
   if len(sys.argv) == 1:
     parser.print_help()
@@ -128,7 +127,7 @@ def main():
   elif args.hexadecimal_input:
     hex_text = args.hexadecimal_input.replace(' ', '')
     if args.revhex:
-      hex_text = binascii.hexlify( binascii.unhexlify( hex_text )[::-1] ).decode()
+      hex_text = binascii.hexlify(binascii.unhexlify(hex_text)[::-1]).decode()
     epoch = fromHex(hex_text)
     fromEpoch(epoch)
     print('')


### PR DESCRIPTION
For consideration, this commit does two things:
  * Automatically/always remove spaces in hex input
  * Add option (`-r, --revhex`) to reverse (by byte) hex input.  Useful when copy/pasting little-endian input.